### PR TITLE
README fix to mach changes in handler syntax

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,7 @@ new Glue()
     var out = Template.precompile(
       fs.readFileSync(filename).toString()
     );
-    done(wrap(filename.replace(extensionRe, '$1.js'), out));
+    done(filename.replace(extensionRe, '$1.js'), out);
   })
   .render(function(err, txt) {
     console.log(txt);


### PR DESCRIPTION
the `wrap()` function is no longer used (changes occurred in c0040be)

ps: @mixu you should update http://mixu.net/gluejs/ too when you have the chance
