### PR TITLE
Can exclude string paths with Windows support

### DIFF
--- a/lib/group.js
+++ b/lib/group.js
@@ -41,12 +41,12 @@ Group.prototype._exclude = function() {
   var self = this;
   this.excluded.forEach(function(expr) {
     self.paths = self.paths.filter(function(p){
-      if(expr.test && expr.test(p)) {
-        return false;
-      } else if(p.substr(expr.length) == expr) {
-        return false;
+      if(expr.test) {   // regexp
+          return !expr.test(p);
       }
-      return true;
+      // string
+      expr = path.normalize(expr);
+      return (p.substr(p.length - expr.length) != expr);
     })
   });
 };

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -18,6 +18,7 @@ exports['given a group'] = {
     done();
 
   },
+
   'can include a directory': function(done) {
     var g = this.group;
     var result = g.include(__dirname+'/fixtures/rendertest/').resolve();
@@ -31,6 +32,16 @@ exports['given a group'] = {
     var g = this.group;
     var result = g.include(__dirname+'/fixtures/rendertest/')
       .exclude(new RegExp('.*simple\\.js$'))
+      .resolve();
+    assert.equal(result.length, 1);
+    assert.equal(result[0], path.normalize(__dirname+'/fixtures/rendertest/has_dependency.js'));
+    done();
+  },
+
+  'can exclude a path by string': function(done) {
+    var g = this.group;
+    var result = g.include(__dirname+'/fixtures/rendertest/')
+      .exclude('simple.js')
       .resolve();
     assert.equal(result.length, 1);
     assert.equal(result[0], path.normalize(__dirname+'/fixtures/rendertest/has_dependency.js'));


### PR DESCRIPTION
Hi,

This PR makes `#exclude` work properly with `string`  parameters, with Windows paths support. This is related to #12.

The `substr` comparison always failed as the starting index was wrong, if comparing with the end of the path was what you wanted.

As the `expr` was not normalized, path comparison failed under Windows because registered paths were already normalized.
