### PR TITLE
Paths under Windows

### DIFF
--- a/lib/glue.js
+++ b/lib/glue.js
@@ -10,7 +10,7 @@ var requireCode = fs.readFileSync(__dirname + '/require/require.new.min.js', 'ut
 
 var defaults = {
   main: 'index.js',
-  reqpath: ''
+  reqpath: process.cwd()
 };
 
 function Renderer(options) {
@@ -206,6 +206,9 @@ Renderer.prototype._fullPath = function(p) {
   }
   if(p.substr(0, 1) == '.') {
     p = path.normalize(this.options.reqpath + path.sep + p);
+  }
+  else {
+    p = path.normalize(p);
   }
   return p;
 };


### PR DESCRIPTION
Hi,

This PR ensures `basepath` works correctly under Windows when specifying relative paths like this: `test/fixtures` (without `./`).

`reqpath` being defined to `''` doesn't work correctly with the `basepath` feature. By defining it to `process.cwd()`, this solves the problem and behaves like you say in the documentation.

Thanks!
