### PR TITLE
Added express middleware support

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -11,7 +11,7 @@ BASIC
 
   --out <path>      File to write. Default: stdout
 
-  --global <name>   Name of the global to export. Default: "Foo"
+  --global <name>   Name of the global to export. Default: "App"
 
   --basepath <path> Base path for the list of files. Default: process.cwd()
 

--- a/index.js
+++ b/index.js
@@ -127,6 +127,39 @@ API.prototype.exclude = function(path) {
   this.options['exclude'].push((path instanceof RegExp ? path : new RegExp(path)));
   return this;
 };
+
+// Express Middleware
+API.middleware = function (opts) {
+
+  // -- Throw error on bad options hash
+  if(!opts || !opts.include) throw new Error('You must define an include in the options hash.');
+  
+  // -- Set default some sane defaults
+  opts.basepath = opts.basepath || (Array.isArray(opts.include) ? opts.include[0] : opts.include);
+  opts.main = opts.main || 'index.js';
+
+  // -- Create an instance of the API to use
+  var glue = new API()
+    .include(opts.include)
+    .basepath(opts.basepath)
+
+  // -- Set options
+  Object.keys(opts).forEach(function (key) {
+    if (key == 'include') return;
+    glue.set(key, opts[key]);
+  });
+  
+  // -- Middleware to return
+  return function (req, res, next) {
+
+    // -- Set content-type
+    res.set('Content-Type', 'application/javascript');
+
+    // -- Render file and pipe to response
+    glue.render(res);
+  }
+};
+
 API.prototype.handler = function(regex, fn) {};
 API.prototype.define = function(module, code) {};
 API.prototype.watch = function(onDone) {};

--- a/lib/runner/package-commonjs/index.js
+++ b/lib/runner/package-commonjs/index.js
@@ -22,7 +22,7 @@ module.exports = function(list, options, out, onDone) {
     options = {};
   }
   // unpack options
-  var exportVariableName = options['export'] || 'foo',
+  var exportVariableName = options['export'] || 'App',
       packageRootFileName,
       // normalize basepath
       basepath = (options.basepath ? path.normalize(options.basepath) : ''),

--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ Usage: gluejs --include <file/dir ...> {OPTIONS}
   --include         Path to import.
   --exclude         JS regular expression string to match against the included paths
   --out             File to write. Default: stdout
-  --global          Name of the global to export. Default: "Foo"
+  --global          Name of the global to export. Default: "App"
   --basepath        Base path for relative file paths. Default: process.cwd()
   --main            Name of the main file/module to export. Default: index.js
 


### PR DESCRIPTION
- Added express middleware support.
- Normalized the default global variable exported from the package for consistency. Some docs read "Foo" some read "App" and the code defined it as "foo". 

Default implementation should look like:

```
var express = require('express');
var glue = require('gluejs').middleware;

var app = express();

app.use(express.logger('dev'));

app.use('/js/app.js', glue({
  include: './public/js'
}));
app.use(express.static(__dirname + '/public'));

app.listen(3000);
```

Notice that `include` option is the only required parameter. The `basepath` will default to the `include` path and the `main` file will default to `index.js` in the `include` path. All other options can be defined in the hash as well. 

Let me know if you have any questions/comments/improvements.
