### PR TITLE
Express Middleware Support

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,11 +130,10 @@ API.prototype.exclude = function(path) {
 
 // Express Middleware
 API.middleware = function (opts) {
-
-  // -- Throw error on bad options hash
-  if(!opts || !opts.include) throw new Error('You must define an options hash with an include property.');
   
   // -- Set some sane defaults
+  opts = opts || {};
+  opts.include = opts.include || './lib';
   opts.basepath = opts.basepath || (Array.isArray(opts.include) ? opts.include[0] : opts.include);
   opts.main = opts.main || 'index.js';
 
@@ -143,7 +142,7 @@ API.middleware = function (opts) {
     .include(opts.include)    // Use API function to define
     .basepath(opts.basepath)  // Use API function to define
 
-  // -- Set options (Clobber the glue.options hash with the passed options hash)
+  // -- All other options are set by clobbering the glue.options hash
   Object.keys(opts).forEach(function (key) {
     glue.set(key, opts[key]);
   });

--- a/index.js
+++ b/index.js
@@ -127,6 +127,41 @@ API.prototype.exclude = function(path) {
   this.options['exclude'].push((path instanceof RegExp ? path : new RegExp(path)));
   return this;
 };
+
+// Express Middleware
+API.middleware = function (opts) {
+
+  // -- Throw error on bad options hash
+  if(!opts || !opts.include) throw new Error('You must define an options hash with an include property.');
+  
+  // -- Set some sane defaults
+  opts.basepath = opts.basepath || (Array.isArray(opts.include) ? opts.include[0] : opts.include);
+  opts.main = opts.main || 'index.js';
+
+  // -- Create an instance of the API to use
+  var glue = new API()
+    .include(opts.include)    // Use API function to define
+    .basepath(opts.basepath)  // Use API function to define
+
+  // -- Set options (Clobber the glue.options hash with the passed options hash)
+  Object.keys(opts).forEach(function (key) {
+    glue.set(key, opts[key]);
+  });
+  
+  // -- Middleware to return
+  return function (req, res, next) {
+
+    // -- Return all non GET requests
+    if('GET' !== req.method) return next();
+
+    // -- Set content-type
+    res.set('Content-Type', 'application/javascript');
+
+    // -- Render file and pipe to response
+    glue.render(res);
+  }
+};
+
 API.prototype.handler = function(regex, fn) {};
 API.prototype.define = function(module, code) {};
 API.prototype.watch = function(onDone) {};

--- a/lib/runner/package-commonjs/index.js
+++ b/lib/runner/package-commonjs/index.js
@@ -22,7 +22,7 @@ module.exports = function(list, options, out, onDone) {
     options = {};
   }
   // unpack options
-  var exportVariableName = options['export'] || 'foo',
+  var exportVariableName = options['export'] || 'Foo',
       packageRootFileName,
       // normalize basepath
       basepath = (options.basepath ? path.normalize(options.basepath) : ''),


### PR DESCRIPTION
My initial thought after finishing up is that this functionality belongs in a plugin/component and not core because it consumes the API rather than adds to it. However, the marketeer in me also knows that `gluejs` won't survive the unsteady waters of node module development unless the n00bs can plug-n-play. With that said, this feature is pretty straight forward and a good ground floor to begin supporting `express` out of the box. 

I originally had a **highly** opinionated set of defaults that I eventually neglected for simplicity in setup. The interface I propose here only requires one parameter and all other options are left as opt-in – define them if you need them, ignore them and they'll be set to `glue`'s defaults. This gets you up on your feet quick.

Middleware can be defined with `app.use()`:

``` javascript
var glue = require('gluejs').middleware;

app.use('/js/app.js', glue({
  include: './lib'
}));
```

Or at the route level:

``` javascript
app.use(app.router);
app.get('/js/app.js', glue({
  include: './lib'
}));
```

The `basepath` defaults to the `include` path and `main` defaults to an `index.js` script in the `include` directory, so each of the above will default to:

``` bash
$ gluejs \
     --include './lib' \
     --basepath './lib' \
     --main 'index.js'
```

And can be requested in HTML thusly:

``` HTML
<script src="/js/app.js"></script>
<script> 
  console.log(window.Foo); 
</script>
```

The necessity for defining an include could be stripped out if we assume a convention of using `lib/` directory in the `cwd` for main include:

``` javascript
app.use('/js/app.js', glue());
```

But this seemed a little opinionated and I wanted you to weigh in first so I added it as a separate commit. Let me know how this looks and if there is anything else you would like to consider.
