### PR TITLE
Use setHeader, so there is compatibility with Express and Connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ API.middleware = function (opts) {
     if('GET' !== req.method) return next();
 
     // -- Set content-type
-    res.set('Content-Type', 'application/javascript');
+    res.setHeader('Content-Type', 'application/javascript');
 
     // -- Render file and pipe to response
     glue.render(res);


### PR DESCRIPTION
I was attempting to use `grunt-contrib-connect` (v0.7.1) with GlueJS middleware, and was running into an issue when navigating to the the file in my browser. I was seeing:

```
TypeError: Object #<ServerResponse> has no method 'set'
    at Object.handle (/Users/tmcinerney/Code/project/node_modules/gluejs/index.js:175:9)
    at next (/Users/tmcinerney/Code/project/node_modules/grunt-contrib-connect/node_modules/connect/lib/proto.js:193:15)
    at /Users/tmcinerney/Code/project/node_modules/grunt-contrib-connect/node_modules/connect/lib/middleware/directory.js:109:11
    at Object.oncomplete (fs.js:107:15)
```

It looks like Connect doesn't have a `set` method for the response object, so seemingly the correct method to call is `setHeader` which works for both Connect and Express.

In Express, you can see [here](https://github.com/visionmedia/express/blob/07b731add0f79ea7e2a256e743adcbbc11d16c80/lib/patch.js#L20), `setHeader` is the internal function which is aliased in the response object on [these lines](https://github.com/visionmedia/express/blob/07b731add0f79ea7e2a256e743adcbbc11d16c80/lib/response.js#L522-L534).

Thanks!

/cc @svizzari @ryanseddon
