### PR TITLE
Update load-config.js

### DIFF
--- a/lib/runner/amd/load-config.js
+++ b/lib/runner/amd/load-config.js
@@ -7,5 +7,9 @@ module.exports = function loadAMDConfig(filepath) {
   var sandbox = {};
   vm.runInNewContext(fs.readFileSync(filepath).toString(), sandbox);
 
-  return sandbox.require;
+  if (typeof sandbox.require === 'object') {
+    return sandbox.require;
+  } else if (typeof sandbox.requirejs === 'object') {
+    return sandbox.requirejs;
+  }
 };


### PR DESCRIPTION
handle alternative configuration styles supported by RequireJS (e.g. "var require = function existingRequire(...) {...}; var requirejs = {...};")
