### PR TITLE
Make npm install work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "minilog": "~2.0.3",
     "progress": "~1.1.2",
     "browser-resolve": "~1.2.2",
-    "detective": "~2.4.0",
+    "detective": "~3.4.1",
     "amd-resolve": "~0.1.1",
     "amdetective": "0.0.1",
     "resolve": "~0.6.1"


### PR DESCRIPTION
Raising `detective` version to `3.4.1` fixes https://github.com/mixu/gluejs/issues/37
